### PR TITLE
Fix relative dependency transpilation

### DIFF
--- a/.changeset/clean-pianos-destroy.md
+++ b/.changeset/clean-pianos-destroy.md
@@ -1,0 +1,5 @@
+---
+"@stevent-team/favicon-scout": patch
+---
+
+Specify external deps in build command due to [this esbuild bug](https://github.com/evanw/esbuild/issues/1958)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "start": "node dist/index.js",
-    "build": "esbuild src/index.ts --platform=node --target=node16 --format=esm --bundle --external:./node_modules/* --minify --outfile=dist/index.js",
+    "build": "esbuild src/index.ts --platform=node --target=node16 --format=esm --bundle --external:fastify --external:@fastify/cors --external:commander --external:node-fetch --external:node-html-parser --external:sharp --external:sharp-ico --external:./node_modules/* --minify --outfile=dist/index.js",
     "dev": "nodemon --exec \"yarn build && yarn start\" --watch src --ext ts,js",
     "lint": "eslint --ext .ts src",
     "test": "vitest",


### PR DESCRIPTION
Due to this ESBuild bug node_module dependencies currently have to be specified individually in the build command: https://github.com/evanw/esbuild/issues/1958