### PR TITLE
Get Command

### DIFF
--- a/.changeset/selfish-papayas-knock.md
+++ b/.changeset/selfish-papayas-knock.md
@@ -1,0 +1,5 @@
+---
+"@stevent-team/favicon-scout": minor
+---
+
+Implement get command to immediately fetch a favicon

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /node_modules
 /dist
+*.png
+*.webp
+*.jpg

--- a/src/commands/getFavicon.ts
+++ b/src/commands/getFavicon.ts
@@ -1,0 +1,32 @@
+import { createWriteStream, WriteStream } from 'fs'
+import { resolve } from 'path'
+
+import getFavicon from '../getFavicon'
+import fallback from '../fallback'
+
+const getFaviconCommand = async (host: string, { size, out, type }) => {
+  // Get image
+  const url = new URL(host.startsWith('http') ? host : `https://${host}`)
+  const { image } = await getFavicon(url, { size })
+
+  // Resolve out and determine path if not specified
+  const outPath = resolve(out ?? `./favicon.${type}`)
+
+  // Get write stream
+  const isTTY = process.stdout.isTTY
+  const outStream = (!isTTY ? process.stdout : createWriteStream(outPath)) as WriteStream
+
+  // Convert image to buffer
+  const imageBuffer = await image
+    .toFormat(type)
+    .toBuffer()
+    .catch(() => fallback(url.host, size)
+      .toFormat(type)
+      .toBuffer())
+
+  // Write buffer to stream
+  outStream.write(imageBuffer)
+  if (isTTY) outStream.end()
+}
+
+export default getFaviconCommand

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,0 +1,2 @@
+export { default as getFaviconCommand } from './getFavicon'
+export { default as startServerCommand } from './startServer'

--- a/src/commands/startServer.ts
+++ b/src/commands/startServer.ts
@@ -1,0 +1,20 @@
+import { version } from '../../package.json'
+import createApp from '../server'
+
+const startServerCommand = ({ port, host, origins }) => {
+  // If origins is an array, transform regexes
+  const origin: (string | RegExp)[] | string = Array.isArray(origins)
+    ? origins.map(o => (o.startsWith('/') && o.endsWith('/')) ? new RegExp(o.slice(1,-1)) : o)
+    : origins
+
+  // Create server and listen on provided host/port
+  createApp().listen({ port, host }).then(() => {
+    console.log(`🧭 Favicon Scout v${version} running at http://${host}:${port}`)
+    console.log(`Allowing requests from: ${origin}`)
+  }).catch(e => {
+    console.error(e)
+    process.exit(1)
+  })
+}
+
+export default startServerCommand

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
-export const requestHeaders = {
+export const REQUEST_HEADERS = {
   'User-Agent': 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
 }
+
+export const FALLBACK_HEADER_KEY = 'x-fallback'

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -1,7 +1,7 @@
 import sharp, { Sharp } from 'sharp'
 
-const fallback = (domain: string, size = 256): Sharp => {
-  return sharp({
+const fallback = (domain: string, size = 256): Sharp =>
+  sharp({
     text: {
       text: `<span foreground="#FFFFFF" background="#666666">${String.fromCodePoint(domain.codePointAt(0) ?? 32).toLocaleUpperCase()}</span>`,
       align: 'center',
@@ -20,6 +20,5 @@ const fallback = (domain: string, size = 256): Sharp => {
     bottom: Math.ceil(size/4),
     background: { r: 102, b: 102, g: 102, alpha: 1 },
   })
-}
 
 export default fallback

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -1,8 +1,6 @@
 import sharp, { Sharp } from 'sharp'
 
-const fallback = (domain: string, sizeString: string | undefined): Sharp => {
-  const size: number = sizeString ? parseInt(sizeString) || 256 : 256
-
+const fallback = (domain: string, size = 256): Sharp => {
   return sharp({
     text: {
       text: `<span foreground="#FFFFFF" background="#666666">${String.fromCodePoint(domain.codePointAt(0) ?? 32).toLocaleUpperCase()}</span>`,

--- a/src/fetchImage.ts
+++ b/src/fetchImage.ts
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch'
 import sharp, { Sharp } from 'sharp'
 import ico from 'sharp-ico'
-import { requestHeaders } from './constants'
+import { REQUEST_HEADERS } from './constants'
 
 // Try and fetch the favicon from the url
 const fetchImage = async (url: URL): Promise<Sharp> => {
@@ -12,7 +12,7 @@ const fetchImage = async (url: URL): Promise<Sharp> => {
   const res = await fetch(url, {
     //@ts-ignore signal types invalid
     signal: controller.signal,
-    headers: requestHeaders,
+    headers: REQUEST_HEADERS,
   })
   if (!res?.ok) throw new Error('Cannot fetch favicon')
   clearTimeout(timeoutId)

--- a/src/scrapeLink.ts
+++ b/src/scrapeLink.ts
@@ -1,6 +1,6 @@
 import { parse } from 'node-html-parser'
 import fetch from 'node-fetch'
-import { requestHeaders } from './constants'
+import { REQUEST_HEADERS } from './constants'
 
 // Try and find the link to an icon from a page's <link> tags
 const scrapeLink = async (url: URL): Promise<URL> => {
@@ -11,7 +11,7 @@ const scrapeLink = async (url: URL): Promise<URL> => {
   const res = await fetch(url.href, {
     //@ts-ignore signal types invalid
     signal: controller.signal,
-    headers: requestHeaders,
+    headers: REQUEST_HEADERS,
   })
   if (!res?.ok) throw new Error('Cannot fetch webpage')
   clearTimeout(timeoutId)

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,9 @@
-import fastify from 'fastify'
+import fastify, { FastifyReply, FastifyRequest } from 'fastify'
 import cors from '@fastify/cors'
 
 import { name, version } from '../package.json'
+import { FALLBACK_HEADER_KEY } from './constants'
+import fallback from './fallback'
 import getFavicon from './getFavicon'
 
 const createApp = (origin: (string | RegExp)[] | string = '*') => {
@@ -11,10 +13,35 @@ const createApp = (origin: (string | RegExp)[] | string = '*') => {
 
   app.get('/', () => ({ name, version }))
 
-  app.get('/:path', getFavicon)
-  app.get('/:path/:size', getFavicon)
+  app.get('/:path', getFaviconHandler)
+  app.get('/:path/:size', getFaviconHandler)
 
   return app
+}
+
+const getFaviconHandler = async (req: FastifyRequest, res: FastifyReply) => {
+  // Pull out queries
+  const { path, size: sizeParam } = req.params as {
+    path: string,
+    size: string | undefined,
+  }
+
+  // Format arguments
+  const size = sizeParam ? parseInt(sizeParam) : undefined
+  const url = new URL(path.startsWith('http') ? path : `https://${path}`)
+
+  // Get Favicon
+  const { image, didFallback } = await getFavicon(url, { size })
+
+  // Write headers
+  res.type('image/webp')
+  res.header(FALLBACK_HEADER_KEY, didFallback)
+
+  // Return image
+  return image.webp().toBuffer().catch(() => {
+    res.header(FALLBACK_HEADER_KEY, 'true')
+    return fallback(url.host, size).webp().toBuffer()
+  })
 }
 
 export default createApp

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,7 @@
+import { InvalidArgumentError } from 'commander'
+
+export const parseIntArgument = v => {
+  const parsed = parseInt(v)
+  if (isNaN(parsed)) throw new InvalidArgumentError('Not a valid number')
+  return parsed
+}

--- a/test/getFavicon.test.ts
+++ b/test/getFavicon.test.ts
@@ -18,13 +18,13 @@ describe('getFavicon', async () => {
   // Successful favicons
   await fetchURLs(testURLs.successful).then(results => results.forEach(res => it(
     `returns a successful favicon (not a fallback) for ${res.raw.req.url}`,
-    () => expect(res.headers['x-fallback']).toBe('false'),
+    () => expect(res.headers['x-fallback']).toBe(false),
   )))
 
   // Fallback favicons
   await fetchURLs(testURLs.fallback).then(results => results.forEach(res => it(
     `returns a fallback favicon for ${res.raw.req.url}`,
-    () => expect(res.headers['x-fallback']).toBe('true'),
+    () => expect(res.headers['x-fallback']).toBe(true),
   )))
 
   // Sizes


### PR DESCRIPTION
Implements a get command for immediately fetching a favicon.
```
Usage: favicon-scout get [options] <host>

Fetch the favicon from a specified url

Arguments:
  host               host to fetch the favicon for

Options:
  -s, --size <size>  rectangular pixel size of favicon (default: 3000)
  -o, --out <out>    path to save favicon to if not using stdout
  -t, --type <type>  image type to save favicon (overrides file extension if provided) (default: "webp")
  -h, --help         display help for command
  ```